### PR TITLE
Make PATCH method compressible

### DIFF
--- a/lib/degzipper/middleware.rb
+++ b/lib/degzipper/middleware.rb
@@ -5,7 +5,7 @@ module Degzipper
     end
 
     def method_handled?(env)
-      !!(env['REQUEST_METHOD'] =~ /(POST|PUT)/)
+      !!(env['REQUEST_METHOD'] =~ /(POST|PUT|PATCH)/)
     end
 
     def encoding_handled?(env)


### PR DESCRIPTION
The PATCH HTTP method has body content just like PUT and POST.  Since
this body has the potential to be very large, we should allow compressed
PATCH content bodies.
