### PR TITLE
Fix no-utf encoding and add the `real` deflate implementation

### DIFF
--- a/lib/degzipper/middleware.rb
+++ b/lib/degzipper/middleware.rb
@@ -23,13 +23,19 @@ module Degzipper
     end
 
     def encoding_handled?(encoding)
-      ['gzip', 'deflate'].include? encoding
+      ['gzip', 'zlib', 'deflate'].include? encoding
     end
 
     def decode(input, content_encoding)
       case content_encoding
         when 'gzip' then Zlib::GzipReader.new(input).read
-        when 'deflate' then Zlib::Inflate.inflate(input.read)
+        when 'zlib' then Zlib::Inflate.inflate(input.string)
+        when 'deflate'
+          stream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
+          content = stream.inflate(input.string)
+          stream.finish
+          stream.close
+          content
       end
     end
   end


### PR DESCRIPTION
Hi

We'd found a problem while using this library. Some requests failed to process on certain servers, but on our dev machines we couldn't reproduce it. The investigation of the problem showed that the issue in the default encoding of StringIO. Somehow it were set to "US-ASCII" and following json dump failed with a message:

``` bash
Failure/Error: body = JSON.dump(
Encoding::InvalidByteSequenceError: 
```

Another problem was in implementation of "deflate" encoding. The gem uses standard library Zlib which has Deflate/Inflate classes. But they(according to these webpages http://ruby-doc.org/stdlib-2.1.1/libdoc/zlib/rdoc/Zlib/Inflate.html & https://en.wikipedia.org/wiki/Zlib) expects a header and trailer at the begging of a content. As the result a server fails to process a deflate content. So I've made changes and now the gem supports three content encoding: gzip, zlib(previously deflate) and deflate. All implementation now have a test coverage.
