### PR TITLE
Handle tempfiles as well

### DIFF
--- a/lib/degzipper/middleware.rb
+++ b/lib/degzipper/middleware.rb
@@ -27,12 +27,15 @@ module Degzipper
     end
 
     def decode(input, content_encoding)
+      # type of input depends on CONTENT_LENGTH
+      # if CONTENT_LENGTH < 20k it's StringIO; if more it's Tempfile
+      # that's why use only common methods of these types
       case content_encoding
         when 'gzip' then Zlib::GzipReader.new(input).read
-        when 'zlib' then Zlib::Inflate.inflate(input.string)
+        when 'zlib' then Zlib::Inflate.inflate(input.read)
         when 'deflate'
           stream = Zlib::Inflate.new(-Zlib::MAX_WBITS)
-          content = stream.inflate(input.string)
+          content = stream.inflate(input.read)
           stream.finish
           stream.close
           content

--- a/spec/degzipper_spec.rb
+++ b/spec/degzipper_spec.rb
@@ -59,6 +59,20 @@ RSpec.describe Degzipper::Middleware do
         'length' => 6
       )
     end
+
+    it 'handles a tmp files as well' do
+      Tempfile.open('degzipper') do |stream|
+        stream << compress('hello')
+        stream.rewind
+        resp = make_request(stream, type)
+
+        expect(resp).to eq(
+          'body' => 'hello',
+          'content_encoding' => nil,
+          'length' => 5
+        )
+      end
+    end
   end
 
   context 'gzip' do


### PR DESCRIPTION
Hi

Sorry to say, but yesterday I've broken this gem. ENV['rack.input'] isn't always StringIO and for a big CONTENT_LENGTH it becomes a Tempfile. That's why using method `#string` is wrong and it should be replaced by common for both classes `#read`. Also I've added a specs for that case to prevent this situation in future
